### PR TITLE
Small improves

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip3 install -r requirements.txt
 ```
 Second, run the tool with the needed flags:
 ```
-python3 KatzKatz.py -f [FILENAME]
+python3 katzkatz.py -f [FILENAME]
 ```
 
 ## Options to consider

--- a/katzkatz.py
+++ b/katzkatz.py
@@ -99,7 +99,7 @@ def parser(input_file):
     try:
         # regex to get each paragraph output
         paragraph_regex = re.compile(
-            r"(?i)\s*(msv|tspkg|wdigest|kerberos|ssp|credman)(:|.*)\n(((\t |\t\t).*\n)+)", flags=re.M)
+            r"(?i)\s*(msv|tspkg|wdigest|kerberos|ssp|credman)(:|.*)\n(((\t |\t\t| {9}).*\n)+)", flags=re.M)
 
         username_regex = re.compile(r"(?i)(?i)\s+Username.* ((?!\(null\)).*)(?!\$)", flags=re.M)
         password_regex = re.compile(r"\s*\*\s+Password\s+:\s+((?!\(null\)).+)\s*(?!\$)", flags=re.M)


### PR DESCRIPTION
readme.md: typo in filename KatzKatz.py -> katzkatz.py

katzkatz.py: If you didnt create logfile and just copy from console and paste to txt file, then instead of tabs you will have 8 spaces before (msv|tspkg|wdigest|kerberos|ssp|credman) and 9 spaces in username:password:domain parts